### PR TITLE
Changes for creation of lists in Neo4j

### DIFF
--- a/biocypher/_config/test_schema_config.yaml
+++ b/biocypher/_config/test_schema_config.yaml
@@ -31,6 +31,7 @@ protein:
     name: str
     score: float
     taxon: int
+    genes: str[]
 
 microRNA:
   represented_as: node

--- a/biocypher/_create.py
+++ b/biocypher/_create.py
@@ -119,7 +119,7 @@ class BioCypherNode:
 
             elif isinstance(v, list):
                 self.properties[k] = (
-                    ', '.join(v).replace(
+                    '**'.join(v).replace(
                         os.linesep,
                         ' ',
                     ).replace(

--- a/biocypher/_create.py
+++ b/biocypher/_create.py
@@ -119,13 +119,15 @@ class BioCypherNode:
 
             elif isinstance(v, list):
                 self.properties[k] = (
-                    '**'.join(v).replace(
-                        os.linesep,
-                        ' ',
-                    ).replace(
-                        '\n',
-                        ' ',
-                    ).replace('\r', ' ')
+                    [
+                        val.replace(
+                            os.linesep,
+                            ' ',
+                        ).replace(
+                            '\n',
+                            ' ',
+                        ).replace('\r', ' ') for val in v
+                    ]
                 )
 
     def get_id(self) -> str:

--- a/biocypher/_write.py
+++ b/biocypher/_write.py
@@ -450,6 +450,8 @@ class BatchWriter:
                     elif v in ['bool', 'boolean']:
                         # TODO Neo4j boolean support / spelling?
                         props_list.append(f'{k}:boolean')
+                    elif v == 'str[]' or v == 'string[]':
+                        props_list.append(f'{k}:string[]')
                     else:
                         props_list.append(f'{k}')
 

--- a/biocypher/_write.py
+++ b/biocypher/_write.py
@@ -450,7 +450,7 @@ class BatchWriter:
                     elif v in ['bool', 'boolean']:
                         # TODO Neo4j boolean support / spelling?
                         props_list.append(f'{k}:boolean')
-                    elif v == 'str[]' or v == 'string[]':
+                    elif v in ['str[]', 'string[]']:
                         props_list.append(f'{k}:string[]')
                     else:
                         props_list.append(f'{k}')

--- a/biocypher/_write.py
+++ b/biocypher/_write.py
@@ -991,11 +991,19 @@ class BatchWriter:
         Returns:
             str: a bash command for neo4j-admin import
         """
-
-        import_call = (
+        
+        if self.delim == "\t":         
+            import_call = (
             f'bin/neo4j-admin import --database={self.db_name} '
-            f'--delimiter="{self.delim}" --array-delimiter="{self.adelim}" '
-        )
+            f'--delimiter="\\t" --array-delimiter="{self.adelim}" ')
+        elif self.adelim == "\t":            
+            import_call = (
+                f'bin/neo4j-admin import --database={self.db_name} '
+                f'--delimiter="{self.delim}" --array-delimiter="\\t" ')
+        else:                    
+            import_call = (
+                f'bin/neo4j-admin import --database={self.db_name} '
+                f'--delimiter="{self.delim}" --array-delimiter="{self.adelim}" ')
 
         if self.quote == "'":
             import_call += f'--quote="{self.quote}" '

--- a/biocypher/_write.py
+++ b/biocypher/_write.py
@@ -551,11 +551,6 @@ class BatchWriter:
                             plist.append(
                                 self.quote + self.adelim.join(p) + self.quote
                             )
-                        elif '**' in p:
-                            plist.append(
-                                self.quote + p.replace('**', self.adelim) +
-                                self.quote
-                            )
                         else:
                             plist.append(self.quote + str(p) + self.quote)
 

--- a/biocypher/_write.py
+++ b/biocypher/_write.py
@@ -421,7 +421,7 @@ class BatchWriter:
         for label, props in self.node_property_dict.items():
             # create header CSV with ID, properties, labels
 
-            id = ':ID'
+            _id = ':ID'
 
             # to programmatically define properties to be written, the
             # data would have to be parsed before writing the header.
@@ -457,7 +457,7 @@ class BatchWriter:
 
                 # create list of lists and flatten
                 # removes need for empty check of property list
-                out_list = [[id], props_list, [':LABEL']]
+                out_list = [[_id], props_list, [':LABEL']]
                 out_list = [val for sublist in out_list for val in sublist]
 
                 with open(header_path, 'w', encoding='utf-8') as f:

--- a/biocypher/_write.py
+++ b/biocypher/_write.py
@@ -548,10 +548,15 @@ class BatchWriter:
                         plist.append(str(p))
                     else:
                         if isinstance(p, list):
-                            plist.append(self.quote + self.adelim.join(p) + self.quote)
-                        elif "**" in p:
-                            plist.append(self.quote + p.replace("**", self.adelim) + self.quote)
-                        else:                            
+                            plist.append(
+                                self.quote + self.adelim.join(p) + self.quote
+                            )
+                        elif '**' in p:
+                            plist.append(
+                                self.quote + p.replace('**', self.adelim) +
+                                self.quote
+                            )
+                        else:
                             plist.append(self.quote + str(p) + self.quote)
 
                 line.append(self.delim.join(plist))
@@ -867,10 +872,15 @@ class BatchWriter:
                         plist.append(str(p))
                     else:
                         if isinstance(p, list):
-                            plist.append(self.quote + self.adelim.join(p) + self.quote)
-                        elif "**" in p:
-                            plist.append(self.quote + p.replace("**", self.adelim) + self.quote)
-                        else:                            
+                            plist.append(
+                                self.quote + self.adelim.join(p) + self.quote
+                            )
+                        elif '**' in p:
+                            plist.append(
+                                self.quote + p.replace('**', self.adelim) +
+                                self.quote
+                            )
+                        else:
                             plist.append(self.quote + str(p) + self.quote)
 
                 lines.append(
@@ -991,19 +1001,15 @@ class BatchWriter:
         Returns:
             str: a bash command for neo4j-admin import
         """
-        
-        if self.delim == "\t":         
-            import_call = (
+
+        # escape backslashes in self.delim and self.adelim
+        delim = self.delim.replace('\\', '\\\\')
+        adelim = self.adelim.replace('\\', '\\\\')
+
+        import_call = (
             f'bin/neo4j-admin import --database={self.db_name} '
-            f'--delimiter="\\t" --array-delimiter="{self.adelim}" ')
-        elif self.adelim == "\t":            
-            import_call = (
-                f'bin/neo4j-admin import --database={self.db_name} '
-                f'--delimiter="{self.delim}" --array-delimiter="\\t" ')
-        else:                    
-            import_call = (
-                f'bin/neo4j-admin import --database={self.db_name} '
-                f'--delimiter="{self.delim}" --array-delimiter="{self.adelim}" ')
+            f'--delimiter="{delim}" --array-delimiter="{adelim}" '
+        )
 
         if self.quote == "'":
             import_call += f'--quote="{self.quote}" '

--- a/biocypher/_write.py
+++ b/biocypher/_write.py
@@ -545,7 +545,12 @@ class BatchWriter:
                     ]:
                         plist.append(str(p))
                     else:
-                        plist.append(self.quote + str(p) + self.quote)
+                        if isinstance(p, list):
+                            plist.append(self.quote + self.adelim.join(p) + self.quote)
+                        elif "**" in p:
+                            plist.append(self.quote + p.replace("**", self.adelim) + self.quote)
+                        else:                            
+                            plist.append(self.quote + str(p) + self.quote)
 
                 line.append(self.delim.join(plist))
             line.append(labels)
@@ -859,7 +864,12 @@ class BatchWriter:
                     ]:
                         plist.append(str(p))
                     else:
-                        plist.append(self.quote + str(p) + self.quote)
+                        if isinstance(p, list):
+                            plist.append(self.quote + self.adelim.join(p) + self.quote)
+                        elif "**" in p:
+                            plist.append(self.quote + p.replace("**", self.adelim) + self.quote)
+                        else:                            
+                            plist.append(self.quote + str(p) + self.quote)
 
                 lines.append(
                     self.delim.join(

--- a/test/test_write.py
+++ b/test/test_write.py
@@ -122,9 +122,9 @@ def test_write_node_data_headers_import_call(bw):
         c = f.read()
 
     assert (
-        passed and
-        p == ':ID;name;score:double;taxon:long;id;preferred_id;:LABEL' and
-        m == ':ID;name;taxon:long;id;preferred_id;:LABEL' and c ==
+        passed and p ==
+        ':ID;name;score:double;taxon:long;genes:string[];id;preferred_id;:LABEL'
+        and m == ':ID;name;taxon:long;id;preferred_id;:LABEL' and c ==
         f'bin/neo4j-admin import --database=neo4j --delimiter=";" --array-delimiter="|" --quote="\'" --force=true --nodes="{path}/Protein-header.csv,{path}/Protein-part.*" --nodes="{path}/MicroRNA-header.csv,{path}/MicroRNA-part.*" '
     )
 
@@ -172,6 +172,7 @@ def _get_nodes(l: int) -> list:
                 'score': 4 / (i + 1),
                 'name': 'StringProperty1',
                 'taxon': 9606,
+                'genes': ['gene1', 'gene2'],
             },
         )
         nodes.append(bnp)
@@ -199,6 +200,7 @@ def test_property_types(bw):
                 'score': 4 / (i + 1),
                 'name': 'StringProperty1',
                 'taxon': 9606,
+                'genes': ['gene1', 'gene2'],
             },
         )
         nodes.append(bnp)
@@ -215,10 +217,10 @@ def test_property_types(bw):
         header = f.read()
 
     assert (
-        passed and
-        header == ':ID;name;score:double;taxon:long;id;preferred_id;:LABEL' and
-        data ==
-        "p1;'StringProperty1';4.0;9606;'p1';'id';Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\np2;'StringProperty1';2.0;9606;'p2';'id';Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\np3;'StringProperty1';1.3333333333333333;9606;'p3';'id';Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\np4;'StringProperty1';1.0;9606;'p4';'id';Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\n"
+        passed and header ==
+        ':ID;name;score:double;taxon:long;genes:string[];id;preferred_id;:LABEL'
+        and data ==
+        "p1;'StringProperty1';4.0;9606;'gene1|gene2';'p1';'id';Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\np2;'StringProperty1';2.0;9606;'gene1|gene2';'p2';'id';Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\np3;'StringProperty1';1.3333333333333333;9606;'gene1|gene2';'p3';'id';Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\np4;'StringProperty1';1.0;9606;'gene1|gene2';'p4';'id';Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\n"
     )
 
 
@@ -238,7 +240,7 @@ def test_write_node_data_from_list(bw):
 
     assert (
         passed and pr ==
-        "p1;'StringProperty1';4.0;9606;'p1';'uniprot';Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\np2;'StringProperty1';2.0;9606;'p2';'uniprot';Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\np3;'StringProperty1';1.3333333333333333;9606;'p3';'uniprot';Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\np4;'StringProperty1';1.0;9606;'p4';'uniprot';Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\n"
+        "p1;'StringProperty1';4.0;9606;'gene1|gene2';'p1';'uniprot';Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\np2;'StringProperty1';2.0;9606;'gene1|gene2';'p2';'uniprot';Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\np3;'StringProperty1';1.3333333333333333;9606;'gene1|gene2';'p3';'uniprot';Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\np4;'StringProperty1';1.0;9606;'gene1|gene2';'p4';'uniprot';Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\n"
         and mi ==
         "m1;'StringProperty1';9606;'m1';'mirbase';MicroRNA|NoncodingRNAProduct|RNAProduct|GeneProductMixin|Transcript|NucleicAcidEntity|GenomicEntity|PhysicalEssence|OntologyClass|MolecularEntity|ChemicalEntity|ChemicalOrDrugOrTreatment|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|NamedThing|Entity|PhysicalEssenceOrOccurrent|ThingWithTaxon|GeneOrGeneProduct|MacromolecularMachineMixin\nm2;'StringProperty1';9606;'m2';'mirbase';MicroRNA|NoncodingRNAProduct|RNAProduct|GeneProductMixin|Transcript|NucleicAcidEntity|GenomicEntity|PhysicalEssence|OntologyClass|MolecularEntity|ChemicalEntity|ChemicalOrDrugOrTreatment|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|NamedThing|Entity|PhysicalEssenceOrOccurrent|ThingWithTaxon|GeneOrGeneProduct|MacromolecularMachineMixin\nm3;'StringProperty1';9606;'m3';'mirbase';MicroRNA|NoncodingRNAProduct|RNAProduct|GeneProductMixin|Transcript|NucleicAcidEntity|GenomicEntity|PhysicalEssence|OntologyClass|MolecularEntity|ChemicalEntity|ChemicalOrDrugOrTreatment|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|NamedThing|Entity|PhysicalEssenceOrOccurrent|ThingWithTaxon|GeneOrGeneProduct|MacromolecularMachineMixin\nm4;'StringProperty1';9606;'m4';'mirbase';MicroRNA|NoncodingRNAProduct|RNAProduct|GeneProductMixin|Transcript|NucleicAcidEntity|GenomicEntity|PhysicalEssence|OntologyClass|MolecularEntity|ChemicalEntity|ChemicalOrDrugOrTreatment|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|NamedThing|Entity|PhysicalEssenceOrOccurrent|ThingWithTaxon|GeneOrGeneProduct|MacromolecularMachineMixin\n"
     )
@@ -263,7 +265,7 @@ def test_write_node_data_from_gen(bw):
 
     assert (
         passed and pr ==
-        "p1;'StringProperty1';4.0;9606;'p1';'uniprot';Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\np2;'StringProperty1';2.0;9606;'p2';'uniprot';Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\np3;'StringProperty1';1.3333333333333333;9606;'p3';'uniprot';Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\np4;'StringProperty1';1.0;9606;'p4';'uniprot';Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\n"
+        "p1;'StringProperty1';4.0;9606;'gene1|gene2';'p1';'uniprot';Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\np2;'StringProperty1';2.0;9606;'gene1|gene2';'p2';'uniprot';Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\np3;'StringProperty1';1.3333333333333333;9606;'gene1|gene2';'p3';'uniprot';Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\np4;'StringProperty1';1.0;9606;'gene1|gene2';'p4';'uniprot';Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\n"
         and mi ==
         "m1;'StringProperty1';9606;'m1';'mirbase';MicroRNA|NoncodingRNAProduct|RNAProduct|GeneProductMixin|Transcript|NucleicAcidEntity|GenomicEntity|PhysicalEssence|OntologyClass|MolecularEntity|ChemicalEntity|ChemicalOrDrugOrTreatment|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|NamedThing|Entity|PhysicalEssenceOrOccurrent|ThingWithTaxon|GeneOrGeneProduct|MacromolecularMachineMixin\nm2;'StringProperty1';9606;'m2';'mirbase';MicroRNA|NoncodingRNAProduct|RNAProduct|GeneProductMixin|Transcript|NucleicAcidEntity|GenomicEntity|PhysicalEssence|OntologyClass|MolecularEntity|ChemicalEntity|ChemicalOrDrugOrTreatment|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|NamedThing|Entity|PhysicalEssenceOrOccurrent|ThingWithTaxon|GeneOrGeneProduct|MacromolecularMachineMixin\nm3;'StringProperty1';9606;'m3';'mirbase';MicroRNA|NoncodingRNAProduct|RNAProduct|GeneProductMixin|Transcript|NucleicAcidEntity|GenomicEntity|PhysicalEssence|OntologyClass|MolecularEntity|ChemicalEntity|ChemicalOrDrugOrTreatment|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|NamedThing|Entity|PhysicalEssenceOrOccurrent|ThingWithTaxon|GeneOrGeneProduct|MacromolecularMachineMixin\nm4;'StringProperty1';9606;'m4';'mirbase';MicroRNA|NoncodingRNAProduct|RNAProduct|GeneProductMixin|Transcript|NucleicAcidEntity|GenomicEntity|PhysicalEssence|OntologyClass|MolecularEntity|ChemicalEntity|ChemicalOrDrugOrTreatment|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|NamedThing|Entity|PhysicalEssenceOrOccurrent|ThingWithTaxon|GeneOrGeneProduct|MacromolecularMachineMixin\n"
     )
@@ -280,6 +282,7 @@ def test_write_node_data_from_gen_no_props(bw):
                 'score': 4 / (i + 1),
                 'name': 'StringProperty1',
                 'taxon': 9606,
+                'genes': ['gene1', 'gene2'],
             },
         )
         nodes.append(bnp)
@@ -305,7 +308,7 @@ def test_write_node_data_from_gen_no_props(bw):
 
     assert (
         passed and pr ==
-        "p1;'StringProperty1';4.0;9606;'p1';'id';Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\np2;'StringProperty1';2.0;9606;'p2';'id';Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\np3;'StringProperty1';1.3333333333333333;9606;'p3';'id';Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\np4;'StringProperty1';1.0;9606;'p4';'id';Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\n"
+        "p1;'StringProperty1';4.0;9606;'gene1|gene2';'p1';'id';Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\np2;'StringProperty1';2.0;9606;'gene1|gene2';'p2';'id';Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\np3;'StringProperty1';1.3333333333333333;9606;'gene1|gene2';'p3';'id';Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\np4;'StringProperty1';1.0;9606;'gene1|gene2';'p4';'id';Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\n"
         and mi ==
         "m1;'m1';'id';MicroRNA|NoncodingRNAProduct|RNAProduct|GeneProductMixin|Transcript|NucleicAcidEntity|GenomicEntity|PhysicalEssence|OntologyClass|MolecularEntity|ChemicalEntity|ChemicalOrDrugOrTreatment|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|NamedThing|Entity|PhysicalEssenceOrOccurrent|ThingWithTaxon|GeneOrGeneProduct|MacromolecularMachineMixin\nm2;'m2';'id';MicroRNA|NoncodingRNAProduct|RNAProduct|GeneProductMixin|Transcript|NucleicAcidEntity|GenomicEntity|PhysicalEssence|OntologyClass|MolecularEntity|ChemicalEntity|ChemicalOrDrugOrTreatment|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|NamedThing|Entity|PhysicalEssenceOrOccurrent|ThingWithTaxon|GeneOrGeneProduct|MacromolecularMachineMixin\nm3;'m3';'id';MicroRNA|NoncodingRNAProduct|RNAProduct|GeneProductMixin|Transcript|NucleicAcidEntity|GenomicEntity|PhysicalEssence|OntologyClass|MolecularEntity|ChemicalEntity|ChemicalOrDrugOrTreatment|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|NamedThing|Entity|PhysicalEssenceOrOccurrent|ThingWithTaxon|GeneOrGeneProduct|MacromolecularMachineMixin\nm4;'m4';'id';MicroRNA|NoncodingRNAProduct|RNAProduct|GeneProductMixin|Transcript|NucleicAcidEntity|GenomicEntity|PhysicalEssence|OntologyClass|MolecularEntity|ChemicalEntity|ChemicalOrDrugOrTreatment|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|NamedThing|Entity|PhysicalEssenceOrOccurrent|ThingWithTaxon|GeneOrGeneProduct|MacromolecularMachineMixin\n"
     )
@@ -398,6 +401,7 @@ def test_write_none_type_property_and_order_invariance(bw):
             'taxon': 9606,
             'score': 1,
             'name': None,
+            'genes': None,
         },
     )
     bnp2 = BioCypherNode(
@@ -405,6 +409,7 @@ def test_write_none_type_property_and_order_invariance(bw):
         node_label='protein',
         properties={
             'name': None,
+            'genes': ['gene1', 'gene2'],
             'score': 2,
             'taxon': 9606,
         },
@@ -435,7 +440,7 @@ def test_write_none_type_property_and_order_invariance(bw):
 
     assert (
         passed and p ==
-        "p1;;1;9606;'p1';'id';Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\np2;;2;9606;'p2';'id';Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\n"
+        "p1;;1;9606;;'p1';'id';Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\np2;;2;9606;'gene1|gene2';'p2';'id';Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\n"
     )
 
 
@@ -468,9 +473,9 @@ def test_accidental_exact_batch_size(bw):
 
     assert (
         passed and pr_lines == 1e4 and mi_lines == 1e4 and
-        not isfile(p1_csv) and not isfile(m1_csv) and
-        p == ':ID;name;score:double;taxon:long;id;preferred_id;:LABEL' and
-        m == ':ID;name;taxon:long;id;preferred_id;:LABEL'
+        not isfile(p1_csv) and not isfile(m1_csv) and p ==
+        ':ID;name;score:double;taxon:long;genes:string[];id;preferred_id;:LABEL'
+        and m == ':ID;name;taxon:long;id;preferred_id;:LABEL'
     )
 
 
@@ -843,7 +848,7 @@ def test_write_offline():
 
     assert (
         passed and pr ==
-        'p1,"StringProperty1",4.0,9606,"p1","uniprot",Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\np2,"StringProperty1",2.0,9606,"p2","uniprot",Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\np3,"StringProperty1",1.3333333333333333,9606,"p3","uniprot",Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\np4,"StringProperty1",1.0,9606,"p4","uniprot",Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\n'
+        'p1,"StringProperty1",4.0,9606,"gene1|gene2","p1","uniprot",Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\np2,"StringProperty1",2.0,9606,"gene1|gene2","p2","uniprot",Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\np3,"StringProperty1",1.3333333333333333,9606,"gene1|gene2","p3","uniprot",Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\np4,"StringProperty1",1.0,9606,"gene1|gene2","p4","uniprot",Protein|GeneProductMixin|ThingWithTaxon|Polypeptide|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|BiologicalEntity|NamedThing|Entity|GeneOrGeneProduct|MacromolecularMachineMixin\n'
         and mi ==
         'm1,"StringProperty1",9606,"m1","mirbase",MicroRNA|NoncodingRNAProduct|RNAProduct|GeneProductMixin|Transcript|NucleicAcidEntity|GenomicEntity|PhysicalEssence|OntologyClass|MolecularEntity|ChemicalEntity|ChemicalOrDrugOrTreatment|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|NamedThing|Entity|PhysicalEssenceOrOccurrent|ThingWithTaxon|GeneOrGeneProduct|MacromolecularMachineMixin\nm2,"StringProperty1",9606,"m2","mirbase",MicroRNA|NoncodingRNAProduct|RNAProduct|GeneProductMixin|Transcript|NucleicAcidEntity|GenomicEntity|PhysicalEssence|OntologyClass|MolecularEntity|ChemicalEntity|ChemicalOrDrugOrTreatment|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|NamedThing|Entity|PhysicalEssenceOrOccurrent|ThingWithTaxon|GeneOrGeneProduct|MacromolecularMachineMixin\nm3,"StringProperty1",9606,"m3","mirbase",MicroRNA|NoncodingRNAProduct|RNAProduct|GeneProductMixin|Transcript|NucleicAcidEntity|GenomicEntity|PhysicalEssence|OntologyClass|MolecularEntity|ChemicalEntity|ChemicalOrDrugOrTreatment|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|NamedThing|Entity|PhysicalEssenceOrOccurrent|ThingWithTaxon|GeneOrGeneProduct|MacromolecularMachineMixin\nm4,"StringProperty1",9606,"m4","mirbase",MicroRNA|NoncodingRNAProduct|RNAProduct|GeneProductMixin|Transcript|NucleicAcidEntity|GenomicEntity|PhysicalEssence|OntologyClass|MolecularEntity|ChemicalEntity|ChemicalOrDrugOrTreatment|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|NamedThing|Entity|PhysicalEssenceOrOccurrent|ThingWithTaxon|GeneOrGeneProduct|MacromolecularMachineMixin\n'
     )
@@ -864,6 +869,7 @@ def test_duplicate_id(bw):
                 'name': 'StringProperty1',
                 'score': 4.32,
                 'taxon': 9606,
+                'genes': ['gene1', 'gene2'],
             },
         )
         nodes.append(bnp)

--- a/test/test_write.py
+++ b/test/test_write.py
@@ -129,6 +129,38 @@ def test_write_node_data_headers_import_call(bw):
     )
 
 
+def test_tab_delimiter(version_node):
+    bl_adapter = BiolinkAdapter(
+        leaves=version_node.leaves,
+        schema=module_data_path('test-biolink-model'),
+        clear_cache=True,
+    )
+    bw = BatchWriter(
+        leaves=version_node.leaves,
+        bl_adapter=bl_adapter,
+        dirname=path,
+        delimiter='\t',
+        array_delimiter='|',
+        quote="'",
+    )
+
+    nodes = _get_nodes(8)
+
+    passed = bw.write_nodes(nodes[:4])
+    passed = bw.write_nodes(nodes[4:])
+    bw.write_import_call()
+
+    call = os.path.join(path, 'neo4j-admin-import-call.sh')
+
+    with open(call) as f:
+        c = f.read()
+
+    assert (
+        passed and c ==
+        f'bin/neo4j-admin import --database=neo4j --delimiter="\t" --array-delimiter="|" --quote="\'" --force=true --nodes="{path}/Protein-header.csv,{path}/Protein-part.*" --nodes="{path}/MicroRNA-header.csv,{path}/MicroRNA-part.*" '
+    )
+
+
 def _get_nodes(l: int) -> list:
     nodes = []
     for i in range(l):


### PR DESCRIPTION
I couldn't create lists from properties in BioCypher's current state. So, I changed some elements to create lists from properties. I added double star mark to join elements of lists then replace this mark with array delimiter in _write.py. With that, I was able to create lists in my properties during admin-import. However, this can be done in _create.py by simply joining lists with selected array delimiter. Another thing I changed is headers. To make headers compatible to list format, I added string[] to header creation so that neo4j can detect the format as a list. Lastly, when I create admin-import-call.sh file after selecting the delimiter as a \t, it writes "    " instead of "\t" which causes error while importing. I manually fixed that issue as well.